### PR TITLE
go.mod: Change import path, README: add warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # goteststats
 
+*This is not a Pulumi product*.
+
 Utility that computes test set stats over a set of JSON files produced
 by `go test -json f.json`.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/t0yv0/goteststats
+module github.com/pulumi/goteststats
 
-go 1.16
+go 1.20


### PR DESCRIPTION
Changes the import path to match the repository's new home.

Adds a warning that this is not a Pulumi product to the README.